### PR TITLE
chore: Ta bort 'workers'-delen fra playwright.config.ts

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,8 +19,6 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 4 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */


### PR DESCRIPTION
Kommentaren stemte ikke med koden, og å begrense til 4 workers høres ut som 'det verste fra begge verdener'